### PR TITLE
Feature/observables

### DIFF
--- a/addon/mixins/ember-hooks.js
+++ b/addon/mixins/ember-hooks.js
@@ -46,14 +46,14 @@ export const useProperties = defaultProps => {
   return self.instanceProxy;
 };
 
-const observable = (obj, scope, anscestors) => {
+const observable = (obj, scope, ancestors) => {
   if (typeof obj === 'object') {
     obj.__isProxy = true;
-    obj.__anscestors = anscestors;
+    obj.__ancestors = ancestors;
 
     Object.keys(obj).forEach(key => {
-      if (key !== '__anscestors' && key !== '__isProxy') {
-        const prev = obj.__anscestors ? [...obj.__anscestors, key] : [key];
+      if (key !== '__ancestors' && key !== '__isProxy') {
+        const prev = obj.__ancestors ? [...obj.__ancestors, key] : [key];
         obj[key] = observable(obj[key], scope, prev);
       }
     });
@@ -66,8 +66,8 @@ const observable = (obj, scope, anscestors) => {
         return scope.get(prop);
       },
       set(obj, prop, value) {
-        if (obj.__anscestors) {
-          const navigationString = createPropertyNavigationString(obj.__anscestors, prop);
+        if (obj.__ancestors) {
+          const navigationString = createPropertyNavigationString(obj.__ancestors, prop);
           scope.set(navigationString, value);
         } else {
           scope.set(prop, value);

--- a/addon/mixins/ember-hooks.js
+++ b/addon/mixins/ember-hooks.js
@@ -1,4 +1,4 @@
-/* global: clone */
+/* global clone */
 // TODO: figure out how to make clone not global
 
 import Mixin from '@ember/object/mixin';

--- a/addon/mixins/ember-hooks.js
+++ b/addon/mixins/ember-hooks.js
@@ -99,4 +99,4 @@ export const withHooks = (...args) => {
       return config(this.attrs);
     },
   });
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
 'use strict';
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+var path = require('path');
 
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
+  included() {
+    this._super.included.apply(this, arguments);
+    this.import('node_modules/clone/clone.js');
+  },
+
+  treeForVendor(vendorTree) {
+    var cloneTree = new Funnel(path.dirname(require.resolve('clone/clone.js')), {
+      files: ['clone.js'],
+    });
+
+    return new MergeTrees([vendorTree, cloneTree]);
+  },
 };

--- a/package.json
+++ b/package.json
@@ -21,11 +21,14 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "clone": "^2.1.2",
     "ember-cli-babel": "^6.16.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
     "broccoli-asset-rev": "^2.7.0",
+    "broccoli-funnel": "^2.0.2",
+    "broccoli-merge-trees": "^3.0.2",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.5.0",
     "ember-cli-dependency-checker": "^3.0.0",

--- a/tests/dummy/app/components/counter-with-hooks.js
+++ b/tests/dummy/app/components/counter-with-hooks.js
@@ -17,15 +17,15 @@ export default Component.extend(EmberHooksMixin, {
 
     const increment = () => {
       state.countA = state.countA + 1;
-    }
+    };
 
     const incrementNested = () => {
       state.nested.countB = state.nested.countB + 1;
-    }
+    };
 
     const incrementUberNested = () => {
       state.nested.nested.countC++
-    }
+    };
 
     return {
       actions: {

--- a/tests/dummy/app/components/counter-with-hooks.js
+++ b/tests/dummy/app/components/counter-with-hooks.js
@@ -20,7 +20,6 @@ export default Component.extend(EmberHooksMixin, {
     }
 
     const incrementNested = () => {
-      console.log(state.nested);
       state.nested.countB = state.nested.countB + 1;
     }
 

--- a/tests/dummy/app/components/counter-with-hooks.js
+++ b/tests/dummy/app/components/counter-with-hooks.js
@@ -6,26 +6,26 @@ export default Component.extend(EmberHooksMixin, {
   layout,
   hooks() {
     const state = useProperties({
-      count: 0,
+      countA: 0,
       nested: {
-        count: 0,
+        countB: 0,
         nested: {
-          count: 0,
+          countC: 0,
         },
       },
     });
 
     const increment = () => {
-      state.count = state.count + 1;
+      state.countA = state.countA + 1;
     }
 
     const incrementNested = () => {
       console.log(state.nested);
-      state.nested.count = state.nested.count + 1;
+      state.nested.countB = state.nested.countB + 1;
     }
 
     const incrementUberNested = () => {
-      state.nested.nested.count++
+      state.nested.nested.countC++
     }
 
     return {

--- a/tests/dummy/app/templates/components/counter-with-hooks.hbs
+++ b/tests/dummy/app/templates/components/counter-with-hooks.hbs
@@ -1,6 +1,6 @@
-<h3>Count: {{count}}</h3>
+<h3>Count: {{countA}}</h3>
 <button onclick={{action "increment"}}>Increment</button>
-<h3>Nested Count: {{nested.count}}</h3>
+<h3>Nested Count: {{nested.countB}}</h3>
 <button onclick={{action "incrementNested"}}>Increment nested</button>
-<h3>Uber Nested Count: {{nested.nested.count}}</h3>
+<h3>Uber Nested Count: {{nested.nested.countC}}</h3>
 <button onclick={{action "incrementUberNested"}}>Increment Uber Nested</button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,7 +1241,7 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
+broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz#0edf629569bc10bd02cc525f74b9a38e71366a75"
   integrity sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==
@@ -1311,7 +1311,7 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1:
+broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz#f33b451994225522b5c9bcf27d59decfd8ba537d"
   integrity sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==
@@ -1785,7 +1785,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clone@^2.0.0:
+clone@^2.0.0, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=


### PR DESCRIPTION
This PR adds a dependency on `clone` in order to deep copy the `defaultProps` object before proxifying it. 

This enables `useProperties` to return a (proxy-wrapped) plain js object that is unadulterated by ember. The ember state is only updated via the proxy handlers